### PR TITLE
Improves GitGutter colors for SignColumn

### DIFF
--- a/colors/brogrammer.vim
+++ b/colors/brogrammer.vim
@@ -106,3 +106,9 @@ hi cssClassName ctermfg=41 ctermbg=NONE cterm=NONE guifg=#2ecc71 guibg=NONE gui=
 hi cssValueLength ctermfg=62 ctermbg=NONE cterm=NONE guifg=#6c71c4 guibg=NONE gui=NONE
 hi cssCommonAttr ctermfg=41 ctermbg=NONE cterm=NONE guifg=#2ecc71 guibg=NONE gui=NONE
 hi cssBraces ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+
+" GitGutter Customizations
+hi SignColumn ctermfg=244 ctermbg=236 guifg=#838586 guibg=#2f2f2f
+hi GitGutterChangeDefault ctermfg=244 ctermbg=236 guifg=#bbbb00 guibg=#2f2f2f
+hi GitGutterAddDefault ctermfg=2 ctermbg=236 guifg=#009900 guibg=#2f2f2f
+hi GitGutterDeleteDefault ctermfg=1 ctermbg=236 guifg=#ff2222 guibg=#2f2f2f


### PR DESCRIPTION
Makes the SignColumn with the same color of line numbers column and fix background for GitGutterChangeDefault, GitGutterAddDefault and GitGutterDeleteDefault.

Demo:
![demo](https://cloud.githubusercontent.com/assets/353311/9075495/df35e98a-3aeb-11e5-8fcc-52fb07e64c9f.png)
