### PR TITLE
Makes Search and InkSearch more visible

### DIFF
--- a/colors/brogrammer.vim
+++ b/colors/brogrammer.vim
@@ -22,8 +22,8 @@ hi StatusLine ctermfg=231 ctermbg=240 cterm=bold guifg=#ecf0f1 guibg=#575858 gui
 hi StatusLineNC ctermfg=231 ctermbg=240 cterm=NONE guifg=#ecf0f1 guibg=#575858 gui=NONE
 hi Pmenu ctermfg=41 ctermbg=NONE cterm=NONE guifg=#2ecc71 guibg=NONE gui=NONE
 hi PmenuSel ctermfg=NONE ctermbg=238 cterm=NONE guifg=NONE guibg=#444444 gui=NONE
-hi IncSearch ctermfg=234 ctermbg=220 cterm=NONE guifg=#1a1a1a guibg=#f1c40f gui=NONE
-hi Search ctermfg=NONE ctermbg=NONE cterm=underline guifg=NONE guibg=NONE gui=underline
+hi Search term=reverse cterm=bold ctermfg=221 gui=bold guifg=#1a1a1a guibg=#f1c40f
+hi IncSearch term=reverse cterm=bold ctermfg=16 ctermbg=39 gui=bold guifg=#000000 guibg=#6c71c4
 hi Directory ctermfg=62 ctermbg=NONE cterm=NONE guifg=#6c71c4 guibg=NONE gui=NONE
 hi Folded ctermfg=241 ctermbg=234 cterm=NONE guifg=#606060 guibg=#1a1a1a gui=NONE
 


### PR DESCRIPTION
The Search highlight was very poor (just an underline), so I tweaked it to show a yellowish background. But it ended looking exacly the same as the actual IncSearch highlight. So I tweaked the IncSearch to display a purple-ish background. I've keept the Search yellowish since it reminds me a text marker. 

And the demo...
![search-and-incsearch-fix](https://cloud.githubusercontent.com/assets/353311/9098893/f2056b32-3ba2-11e5-979d-33bc1556641d.png)
