### PR TITLE
Makes SpecialKeys visible

### DIFF
--- a/colors/brogrammer.vim
+++ b/colors/brogrammer.vim
@@ -50,7 +50,7 @@ hi Number ctermfg=62 ctermbg=NONE cterm=NONE guifg=#6c71c4 guibg=NONE gui=NONE
 hi Operator ctermfg=167 ctermbg=NONE cterm=bold guifg=#e74c3c guibg=NONE gui=bold
 hi PreProc ctermfg=167 ctermbg=NONE cterm=bold guifg=#e74c3c guibg=NONE gui=bold
 hi Special ctermfg=62 ctermbg=NONE cterm=NONE guifg=#6c71c4 guibg=NONE gui=NONE
-hi SpecialKey ctermfg=22 ctermbg=236 cterm=NONE guifg=#30312a guibg=#2f2f2f gui=NONE
+hi SpecialKey ctermfg=22 ctermbg=236 cterm=NONE guifg=#f1530f guibg=#1a1a1a gui=NONE
 hi Statement ctermfg=167 ctermbg=NONE cterm=bold guifg=#e74c3c guibg=NONE gui=bold
 hi StorageClass ctermfg=68 ctermbg=NONE cterm=NONE guifg=#3498db guibg=NONE gui=NONE
 hi String ctermfg=220 ctermbg=NONE cterm=NONE guifg=#f1c40f guibg=NONE gui=NONE


### PR DESCRIPTION
SpecialKeys are the non ascii characters. They were almost invisible.

And here comes the demo!
![special-chars](https://cloud.githubusercontent.com/assets/353311/9100933/d2ab52e2-3bb6-11e5-982e-7d10ff443648.png)
