### PR TITLE
Fix SpellBad in terminal

### DIFF
--- a/colors/brogrammer.vim
+++ b/colors/brogrammer.vim
@@ -60,6 +60,7 @@ hi Title ctermfg=231 ctermbg=NONE cterm=bold guifg=#ecf0f1 guibg=NONE gui=bold
 hi Todo ctermfg=241 ctermbg=NONE cterm=inverse,bold guifg=#606060 guibg=NONE gui=inverse,bold,italic
 hi Type ctermfg=41 ctermbg=NONE cterm=NONE guifg=#2ecc71 guibg=NONE gui=NONE
 hi Underlined ctermfg=NONE ctermbg=NONE cterm=underline guifg=NONE guibg=NONE gui=underline
+hi SpellBad term=reverse ctermfg=167 ctermbg=224 gui=undercurl guisp=Red¬
 hi rubyClass ctermfg=167 ctermbg=NONE cterm=bold guifg=#e74c3c guibg=NONE gui=bold
 hi rubyFunction ctermfg=41 ctermbg=NONE cterm=NONE guifg=#2ecc71 guibg=NONE gui=NONE
 hi rubyInterpolationDelimiter ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE


### PR DESCRIPTION
The SpellBad highlight in terminal was nearly invisible. I added
a different foreground but it probably is different from the colors used
in the original theme. If you provide me a example on how the original
theme handles spell errors I'd be glad to send another pull request.
