### PR TITLE
Fix characters "c2" "ac" in end of line

### DIFF
--- a/colors/brogrammer.vim
+++ b/colors/brogrammer.vim
@@ -60,7 +60,7 @@ hi Title ctermfg=231 ctermbg=NONE cterm=bold guifg=#ecf0f1 guibg=NONE gui=bold
 hi Todo ctermfg=241 ctermbg=NONE cterm=inverse,bold guifg=#606060 guibg=NONE gui=inverse,bold,italic
 hi Type ctermfg=41 ctermbg=NONE cterm=NONE guifg=#2ecc71 guibg=NONE gui=NONE
 hi Underlined ctermfg=NONE ctermbg=NONE cterm=underline guifg=NONE guibg=NONE gui=underline
-hi SpellBad term=reverse ctermfg=167 ctermbg=224 gui=undercurl guisp=Red¬
+hi SpellBad term=reverse ctermfg=167 ctermbg=224 gui=undercurl guisp=Red
 hi rubyClass ctermfg=167 ctermbg=NONE cterm=bold guifg=#e74c3c guibg=NONE gui=bold
 hi rubyFunction ctermfg=41 ctermbg=NONE cterm=NONE guifg=#2ecc71 guibg=NONE gui=NONE
 hi rubyInterpolationDelimiter ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE


### PR DESCRIPTION
These characters cause error when used in gvim.

```
$ gvim
E254: Cannot allocate color Red¬
```
