### PR TITLE
Fix inconsistency with colorscheme name

### DIFF
--- a/colors/brogrammer.vim
+++ b/colors/brogrammer.vim
@@ -8,7 +8,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let g:colors_name = "Brogrammer"
+let g:colors_name = "brogrammer"
 
 hi Cursor ctermfg=234 ctermbg=231 cterm=NONE guifg=#1a1a1a guibg=#ecf0f1 gui=NONE
 hi Visual ctermfg=NONE ctermbg=238 cterm=NONE guifg=NONE guibg=#444444 gui=NONE


### PR DESCRIPTION
This mistake causes an error when sourcing my vimrc, it's caused by the colorscheme being "brogrammer" and `g:colors_name` is "Brogrammer". Making them both lowercase solves the issue. :smile:
