### PR TITLE
Force dark tab line coloring

### DIFF
--- a/colors/brogrammer.vim
+++ b/colors/brogrammer.vim
@@ -26,6 +26,9 @@ hi Search term=reverse cterm=bold ctermfg=15 ctermbg=196 gui=bold guifg=#f7f3ff 
 hi IncSearch term=reverse cterm=bold ctermfg=16 ctermbg=39 gui=bold guifg=#000000 guibg=#6c71c4
 hi Directory ctermfg=62 ctermbg=NONE cterm=NONE guifg=#6c71c4 guibg=NONE gui=NONE
 hi Folded ctermfg=241 ctermbg=234 cterm=NONE guifg=#606060 guibg=#1a1a1a gui=NONE
+hi TabLine ctermfg=241 ctermbg=234 cterm=NONE guifg=#606060 guibg=#1a1a1a gui=NONE
+hi TabLineSel ctermfg=255 ctermbg=234 cterm=NONE guifg=#eeeeee guibg=#1a1a1a gui=NONE
+hi TabLineFill ctermfg=NONE ctermbg=234 cterm=NONE guifg=NONE guibg=#1a1a1a gui=NONE
 
 hi Normal ctermfg=231 ctermbg=234 cterm=NONE guifg=#ecf0f1 guibg=#1a1a1a gui=NONE
 hi Boolean ctermfg=62 ctermbg=NONE cterm=NONE guifg=#6c71c4 guibg=NONE gui=NONE


### PR DESCRIPTION
On my setup (iTerm2 on macOS High Sierra 10.13.5), the tab bar was oddly white-colored, similar to this:
![](https://user-images.githubusercontent.com/5923662/42391101-332aca32-811c-11e8-852e-fedf481b2b6c.png)

This PR forces a dark theme for the tab line.